### PR TITLE
REFACTOR : 브라우저와 Redis에 저장되는 만료 시간 통일

### DIFF
--- a/src/main/java/com/sangbu3jo/elephant/auth/redis/RefreshTokenRepository.java
+++ b/src/main/java/com/sangbu3jo/elephant/auth/redis/RefreshTokenRepository.java
@@ -15,7 +15,7 @@ public class RefreshTokenRepository {
   private final RedisTemplate redisTemplate;
 
   // 리프레스 토큰 만료시간
-  private final long RRFRESH_TOKEN_TIME = 60 * 60 * 1000L; // 60분
+  private final long RRFRESH_TOKEN_TIME = 60 * 60 * 24; // 24시간
 
   public void save(final RefreshToken refreshToken) {
     ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();


### PR DESCRIPTION
REFACTOR : 브라우저와 Redis에 저장되는 만료 시간 통일

1000L을 하면 Redis 에서 만료시간이 맵핑이 되지 않아 삭제하고,
24시간으로 수정하였습니다.