### PR TITLE
신고 관련기능 추가,수정 + 알림 관련기능 추가,수정

### DIFF
--- a/src/main/java/com/sangbu3jo/elephant/board/service/BoardService.java
+++ b/src/main/java/com/sangbu3jo/elephant/board/service/BoardService.java
@@ -188,7 +188,7 @@ public class BoardService {
             String notificationContent = "보드 \"" + board.getTitle() + "\" 가 마감까지 얼마남지 않았습니다. (24시간 미만)";
             List<BoardUser> boardUsers = boardUserRepository.findAllByBoardId(board.getId());
             for (BoardUser boardUser : boardUsers) {
-                notificationService.addUserAndSendNotification(boardUser.getUser().getId(), board.getId(), notificationContent);
+                notificationService.boarddDeadlineNotification(boardUser.getUser().getId(), board.getId(), notificationContent);
             }
         }
     }

--- a/src/main/java/com/sangbu3jo/elephant/notification/entity/Notification.java
+++ b/src/main/java/com/sangbu3jo/elephant/notification/entity/Notification.java
@@ -20,6 +20,7 @@ public class Notification{
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    private String type;
     private Long userId;
     private String content;
     private String url;
@@ -51,6 +52,8 @@ public class Notification{
         isRead = read;
     }
 
-
+    public void setType(String type){
+        this.type = type;
+    }
 
 }

--- a/src/main/java/com/sangbu3jo/elephant/notification/service/NotificationService.java
+++ b/src/main/java/com/sangbu3jo/elephant/notification/service/NotificationService.java
@@ -67,7 +67,23 @@ public class NotificationService {
         notification.setContent("\uD83D\uDD14댓글 알림\uD83D\uDD14<br>" + commentAuthor);
         notification.setUrl("http://localhost:8080/api/posts/" + postId);
         notification.setRead(false);
-        notification.setType("comment");
+        notification.setType("Comment");
+
+
+        notificationRepository.save(notification);
+        sendNotificationToUser(userId, notification);
+    }
+
+    // 게시글 신고시 관리자에게 알림 생성 및 전송
+    public void reportPostNotification(Long userId, Long postId, String commentAuthor, String url) {
+        Notification notification = new Notification();
+        LocalDateTime currentTime = LocalDateTime.now(); // 현재 시간 가져오기
+        notification.setCreatedAt(currentTime); // 생성 시간 설정
+        notification.setUserId(userId);
+        notification.setContent("\uD83D\uDD14신고 알림\uD83D\uDD14<br>" + commentAuthor);
+        notification.setUrl("http://localhost:8080/api/posts/" + postId);
+        notification.setRead(false);
+        notification.setType("Report");
 
 
         notificationRepository.save(notification);
@@ -83,7 +99,7 @@ public class NotificationService {
         notification.setContent("\uD83D\uDD14프로젝트 알림\uD83D\uDD14<br>" + addUserAuthor);
         notification.setUrl("http://localhost:8080/api/boards/" + boardId);
         notification.setRead(false);
-        notification.setType("addUserBoard");
+        notification.setType("AddUserBoard");
 
         notificationRepository.save(notification);
         sendNotificationToUser(userId, notification);
@@ -98,7 +114,7 @@ public class NotificationService {
         notification.setContent("\uD83D\uDD14프로젝트 알림\uD83D\uDD14<br>" + inviteAuthor);
         notification.setUrl("http://localhost:8080/api/boards");
         notification.setRead(false);
-        notification.setType("invited");
+        notification.setType("Invited");
 
         notificationRepository.save(notification);
         sendNotificationToUser(userId, notification);

--- a/src/main/java/com/sangbu3jo/elephant/notification/service/NotificationService.java
+++ b/src/main/java/com/sangbu3jo/elephant/notification/service/NotificationService.java
@@ -67,6 +67,8 @@ public class NotificationService {
         notification.setContent("\uD83D\uDD14댓글 알림\uD83D\uDD14<br>" + commentAuthor);
         notification.setUrl("http://localhost:8080/api/posts/" + postId);
         notification.setRead(false);
+        notification.setType("comment");
+
 
         notificationRepository.save(notification);
         sendNotificationToUser(userId, notification);
@@ -81,6 +83,7 @@ public class NotificationService {
         notification.setContent("\uD83D\uDD14프로젝트 알림\uD83D\uDD14<br>" + addUserAuthor);
         notification.setUrl("http://localhost:8080/api/boards/" + boardId);
         notification.setRead(false);
+        notification.setType("addUserBoard");
 
         notificationRepository.save(notification);
         sendNotificationToUser(userId, notification);
@@ -95,6 +98,7 @@ public class NotificationService {
         notification.setContent("\uD83D\uDD14프로젝트 알림\uD83D\uDD14<br>" + inviteAuthor);
         notification.setUrl("http://localhost:8080/api/boards");
         notification.setRead(false);
+        notification.setType("invited");
 
         notificationRepository.save(notification);
         sendNotificationToUser(userId, notification);

--- a/src/main/java/com/sangbu3jo/elephant/notification/service/NotificationService.java
+++ b/src/main/java/com/sangbu3jo/elephant/notification/service/NotificationService.java
@@ -10,6 +10,7 @@ import com.sangbu3jo.elephant.users.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -42,21 +43,37 @@ public class NotificationService {
         }
     }
 
+    @Async
     public void sendNotificationToUser(Long userId, Notification notification) {
         List<SseEmitter> emitters = sseEmitterMap.get(userId);
         if (emitters != null) {
-            emitters.forEach(emitter -> {
+            ObjectMapper objectMapper = new ObjectMapper();
+            objectMapper.registerModule(new JavaTimeModule()); // Java 8 날짜/시간 모듈 등록
+            String notificationJson;
+            try {
+                notificationJson = objectMapper.writeValueAsString(notification);
+            } catch (IOException e) {
+                throw new RuntimeException("알림을 직렬화하는 중 오류 발생", e);
+            }
+
+            List<SseEmitter> emittersToRemove = new ArrayList<>(); // 제거할 emitters를 저장할 리스트 생성
+
+            for (SseEmitter emitter : emitters) {
                 try {
-                    ObjectMapper objectMapper = new ObjectMapper();
-                    objectMapper.registerModule(new JavaTimeModule()); // Java 8 날짜/시간 모듈 등록
-                    String notificationJson = objectMapper.writeValueAsString(notification);
                     emitter.send(SseEmitter.event().data(notificationJson));
                 } catch (IOException e) {
-                    throw new RuntimeException(e);
+                    // 연결이 끊긴 경우, 여기서 처리 가능
+                    emittersToRemove.add(emitter); // 연결이 끊긴 emitter를 제거할 리스트에 추가
+                    System.out.println("SSE 연결이 끊겼습니다.");
                 }
-            });
+            }
+
+            // 연결이 끊긴 emitter를 실제로 제거
+            emitters.removeAll(emittersToRemove);
         }
     }
+
+
 
     // 댓글 작성 시 알림 생성 및 전송
     public void createAndSendNotification(Long userId, Long postId, String commentAuthor, String postTitle) {
@@ -80,8 +97,8 @@ public class NotificationService {
         LocalDateTime currentTime = LocalDateTime.now(); // 현재 시간 가져오기
         notification.setCreatedAt(currentTime); // 생성 시간 설정
         notification.setUserId(userId);
-        notification.setContent("\uD83D\uDD14신고 알림\uD83D\uDD14<br>" + commentAuthor);
-        notification.setUrl("http://localhost:8080/api/posts/" + postId);
+        notification.setContent("\uD83D\uDEA8신고 알림\uD83D\uDEA8<br>" + commentAuthor);
+        notification.setUrl(url);
         notification.setRead(false);
         notification.setType("Report");
 
@@ -96,10 +113,25 @@ public class NotificationService {
         LocalDateTime currentTime = LocalDateTime.now(); // 현재 시간 가져오기
         notification.setCreatedAt(currentTime); // 생성 시간 설정
         notification.setUserId(userId);
-        notification.setContent("\uD83D\uDD14프로젝트 알림\uD83D\uDD14<br>" + addUserAuthor);
+        notification.setContent("\uD83E\uDD17프로젝트 알림\uD83E\uDD17<br>" + addUserAuthor);
         notification.setUrl("http://localhost:8080/api/boards/" + boardId);
         notification.setRead(false);
         notification.setType("AddUserBoard");
+
+        notificationRepository.save(notification);
+        sendNotificationToUser(userId, notification);
+    }
+
+    // 프로젝트에 유저 참여시 알림 생성 및 전송
+    public void boarddDeadlineNotification(Long userId, Long boardId, String addUserAuthor){
+        Notification notification = new Notification();
+        LocalDateTime currentTime = LocalDateTime.now(); // 현재 시간 가져오기
+        notification.setCreatedAt(currentTime); // 생성 시간 설정
+        notification.setUserId(userId);
+        notification.setContent("⏳프로젝트 마감알림⏳<br>" + addUserAuthor);
+        notification.setUrl("http://localhost:8080/api/boards/" + boardId);
+        notification.setRead(false);
+        notification.setType("BoardDeadline");
 
         notificationRepository.save(notification);
         sendNotificationToUser(userId, notification);
@@ -111,7 +143,7 @@ public class NotificationService {
         LocalDateTime currentTime = LocalDateTime.now(); // 현재 시간 가져오기
         notification.setCreatedAt(currentTime); // 생성 시간 설정
         notification.setUserId(userId);
-        notification.setContent("\uD83D\uDD14프로젝트 알림\uD83D\uDD14<br>" + inviteAuthor);
+        notification.setContent("\uD83D\uDCE7프로젝트 알림\uD83D\uDCE7<br>" + inviteAuthor);
         notification.setUrl("http://localhost:8080/api/boards");
         notification.setRead(false);
         notification.setType("Invited");

--- a/src/main/java/com/sangbu3jo/elephant/posts/dto/ReportPostResponseDto.java
+++ b/src/main/java/com/sangbu3jo/elephant/posts/dto/ReportPostResponseDto.java
@@ -1,0 +1,53 @@
+package com.sangbu3jo.elephant.posts.dto;
+
+import com.sangbu3jo.elephant.posts.entity.Post;
+import com.sangbu3jo.elephant.report.entity.Report;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+
+@Getter
+@Setter
+public class ReportPostResponseDto {
+    private Long id;
+    private Long userId;
+    private Long oripostId;
+    private String title;
+    private String content;
+    private String category;
+    private String username;
+    private String nickname;
+    private String files;
+    private Boolean completed;
+    private Integer view_cnt;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
+    private List<PostCommentResponseDto> postCommentList;
+    private String reason;
+
+    public ReportPostResponseDto(Report report) {
+        this.id = report.getId();
+        this.userId = report.getUser().getId();
+        this.oripostId = report.getPost().getId();
+        this.title = report.getPost().getTitle();
+        this.username = report.getUser().getUsername();
+        this.nickname = report.getUser().getNickname();
+        this.content = report.getPost().getContent();
+        this.category = report.getPost().getCategory().getCategoryName();
+        this.completed = report.getPost().getCompleted();
+        this.files = report.getPost().getFiles();
+        this.view_cnt = report.getPost().getViewCnt()==null ? 0 : report.getPost().getViewCnt();
+        this.createdAt = report.getCreatedAt();
+        this.modifiedAt = report.getModifiedAt();
+        this.postCommentList = report.getPost().getCommentList().stream()
+                .map(PostCommentResponseDto::new)
+                .sorted(Comparator.comparing(PostCommentResponseDto::getCreatedAt))
+                .toList();
+        this.userId = report.getUser().getId();
+        this.reason = report.getReason();
+    }
+
+}

--- a/src/main/java/com/sangbu3jo/elephant/posts/entity/Post.java
+++ b/src/main/java/com/sangbu3jo/elephant/posts/entity/Post.java
@@ -2,6 +2,7 @@ package com.sangbu3jo.elephant.posts.entity;
 
 import com.sangbu3jo.elephant.common.TimeStamped;
 import com.sangbu3jo.elephant.posts.dto.PostRequestDto;
+import com.sangbu3jo.elephant.report.entity.Report;
 import com.sangbu3jo.elephant.users.entity.User;
 import jakarta.persistence.*;
 import lombok.Getter;
@@ -50,6 +51,9 @@ public class Post extends TimeStamped {
 
     @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE)
     private List<PostComment> commentList = new ArrayList<>(); //댓글
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE)
+    private List<Report> reportList = new ArrayList<>(); // 신고 목록
 
     public Post(PostRequestDto postRequestDto, User user) {
         this.title = postRequestDto.getTitle();

--- a/src/main/java/com/sangbu3jo/elephant/report/controller/ReportController.java
+++ b/src/main/java/com/sangbu3jo/elephant/report/controller/ReportController.java
@@ -1,0 +1,40 @@
+package com.sangbu3jo.elephant.report.controller;
+
+
+import com.sangbu3jo.elephant.posts.dto.PostResponseDto;
+import com.sangbu3jo.elephant.posts.entity.Post;
+import com.sangbu3jo.elephant.report.dto.ReportRequestDto;
+import com.sangbu3jo.elephant.report.service.ReportService;
+import com.sangbu3jo.elephant.security.UserDetailsImpl;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class ReportController {
+    private final ReportService reportService;
+
+    // 신고당한 게시글을 DB에 저장
+    @PostMapping("/posts/report/{postId}")
+    public ResponseEntity<String> reportPost(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                             @PathVariable Long postId,
+                                             @RequestBody ReportRequestDto reportRequestDto){
+        String result = reportService.reportPost(userDetails.getUser(), postId, reportRequestDto);
+        return ResponseEntity.ok(result);
+    }
+
+    // 신고당한 게시글 조회
+    @GetMapping("/posts/report")
+    public ResponseEntity<List<PostResponseDto>> getReportPosts(@AuthenticationPrincipal UserDetailsImpl userDetails){
+        List<PostResponseDto> posts = reportService.getReportPosts(userDetails.getUser());
+        return ResponseEntity.ok(posts);
+    }
+
+
+}

--- a/src/main/java/com/sangbu3jo/elephant/report/controller/ReportController.java
+++ b/src/main/java/com/sangbu3jo/elephant/report/controller/ReportController.java
@@ -2,6 +2,7 @@ package com.sangbu3jo.elephant.report.controller;
 
 
 import com.sangbu3jo.elephant.posts.dto.PostResponseDto;
+import com.sangbu3jo.elephant.posts.dto.ReportPostResponseDto;
 import com.sangbu3jo.elephant.posts.entity.Post;
 import com.sangbu3jo.elephant.report.dto.ReportRequestDto;
 import com.sangbu3jo.elephant.report.service.ReportService;
@@ -31,8 +32,8 @@ public class ReportController {
 
     // 신고당한 게시글 조회
     @GetMapping("/posts/report")
-    public ResponseEntity<List<PostResponseDto>> getReportPosts(@AuthenticationPrincipal UserDetailsImpl userDetails){
-        List<PostResponseDto> posts = reportService.getReportPosts(userDetails.getUser());
+    public ResponseEntity<List<ReportPostResponseDto>> getReportPosts(@AuthenticationPrincipal UserDetailsImpl userDetails){
+        List<ReportPostResponseDto> posts = reportService.getReportPosts(userDetails.getUser());
         return ResponseEntity.ok(posts);
     }
 

--- a/src/main/java/com/sangbu3jo/elephant/report/dto/ReportRequestDto.java
+++ b/src/main/java/com/sangbu3jo/elephant/report/dto/ReportRequestDto.java
@@ -1,0 +1,10 @@
+package com.sangbu3jo.elephant.report.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ReportRequestDto {
+    private String reason;
+}

--- a/src/main/java/com/sangbu3jo/elephant/report/entity/Report.java
+++ b/src/main/java/com/sangbu3jo/elephant/report/entity/Report.java
@@ -1,0 +1,36 @@
+package com.sangbu3jo.elephant.report.entity;
+
+import com.sangbu3jo.elephant.common.TimeStamped;
+import com.sangbu3jo.elephant.posts.entity.Post;
+import com.sangbu3jo.elephant.users.entity.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor
+public class Report extends TimeStamped {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    // 신고사유
+    @Column(nullable = false)
+    private String reason;
+
+    public Report(Post post, User user, String reason){
+        this.post = post;
+        this.user = user;
+        this.reason = reason;
+    }
+}

--- a/src/main/java/com/sangbu3jo/elephant/report/repository/ReportRepository.java
+++ b/src/main/java/com/sangbu3jo/elephant/report/repository/ReportRepository.java
@@ -1,0 +1,11 @@
+package com.sangbu3jo.elephant.report.repository;
+
+
+import com.sangbu3jo.elephant.posts.entity.Post;
+import com.sangbu3jo.elephant.report.entity.Report;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ReportRepository extends JpaRepository<Report, Long> {
+}

--- a/src/main/java/com/sangbu3jo/elephant/report/service/ReportService.java
+++ b/src/main/java/com/sangbu3jo/elephant/report/service/ReportService.java
@@ -1,0 +1,74 @@
+package com.sangbu3jo.elephant.report.service;
+
+import com.sangbu3jo.elephant.notification.service.NotificationService;
+import com.sangbu3jo.elephant.posts.dto.PostResponseDto;
+import com.sangbu3jo.elephant.posts.entity.Post;
+import com.sangbu3jo.elephant.posts.repository.PostRepository;
+import com.sangbu3jo.elephant.report.dto.ReportRequestDto;
+import com.sangbu3jo.elephant.report.entity.Report;
+import com.sangbu3jo.elephant.report.repository.ReportRepository;
+import com.sangbu3jo.elephant.users.entity.User;
+import com.sangbu3jo.elephant.users.entity.UserRoleEnum;
+import com.sangbu3jo.elephant.users.repository.UserRepository;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ReportService {
+
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+    private final ReportRepository reportRepository;
+    private final NotificationService notificationService;
+
+    // 신고당한 게시글을 DB에 저장
+    public String reportPost(User requestuser, Long postId, ReportRequestDto reportRequestDto) {
+        Post post = postRepository.findById(postId).orElseThrow(
+                () -> new IllegalArgumentException("존재하지 않는 게시글 입니다.")
+        );
+
+        User user = userRepository.findById(requestuser.getId()).orElseThrow(
+                () -> new IllegalArgumentException("존재하지 않는 사용자 입니다.")
+        );
+
+        Report report = new Report(post, user, reportRequestDto.getReason());
+        reportRepository.save(report);
+
+        // 알림 정보 (어드민 유저들에게 전달)
+        List<User> users = userRepository.findAll();
+        for(User adminUser : users) {
+            String notificationContent = user.getNickname() + "님이 \"" + post.getTitle() + "\" 게시글을 신고하였습니다. 사유 : " + reportRequestDto.getReason();
+            String notificationUrl = "/posts/" + post.getId(); // 게시글로 이동할 수 있는 URL
+
+            if(adminUser.getRole().equals(UserRoleEnum.ADMIN)) {
+                notificationService.reportPostNotification(adminUser.getId(), post.getId(), notificationContent, notificationUrl);
+            }
+        }
+
+        return "게시글이 신고되었습니다.";
+    }
+
+    // 신고당한 게시글 조회
+    public List<PostResponseDto> getReportPosts(User requestuser) {
+        if(!requestuser.getRole().equals(UserRoleEnum.ADMIN)){
+            throw new IllegalArgumentException("관리자 기능입니다.");
+        }
+
+        List<Report> reportedPosts = reportRepository.findAll();
+        List<PostResponseDto> postResponseDtos = new ArrayList<>();
+
+        for(Report report : reportedPosts){
+            Post post = report.getPost();
+            PostResponseDto postResponseDto = new PostResponseDto(post);
+            postResponseDtos.add(postResponseDto);
+        }
+
+        return postResponseDtos;
+    }
+}

--- a/src/main/resources/templates/backAdmins.html
+++ b/src/main/resources/templates/backAdmins.html
@@ -129,6 +129,10 @@
             <h2 style="font-size: 1.4rem;
         margin: 10px;">게시물 관리</h2>
         </div>
+        <div class="feature" id="reportPostManagement">
+            <h2 style="font-size: 1.4rem;
+        margin: 10px;">신고 관리</h2>
+        </div>
         <div class="feature" id="commentManagement">
             <h2 style="font-size: 1.4rem;
         margin: 10px;">댓글 관리</h2>
@@ -448,6 +452,7 @@
     const userPerPage = 5;
     const userManagementButton = document.getElementById('userManagement');
     const postManagementButton = document.getElementById('postManagement');
+    const reportPostManagementButton = document.getElementById('reportPostManagement');
     const commentManagementButton = document.getElementById('commentManagement');
     const userInfoList = document.querySelector('.user-info-list');
     const paginationContainer = document.querySelector('.pagination');
@@ -458,6 +463,7 @@
     let totalUsers = 0;
     let users = []; // 사용자 정보를 저장할 배열
     let posts = [];
+    let reportposts = [];
     let comments = [];
 
     // 새로 추가한 내용
@@ -468,6 +474,7 @@
         currentPage = 1;
         users = [];
         posts = [];
+        reportposts = [];
         comments = [];
         fetchAndRenderUsers();
         editButton.textContent = '권한 수정';
@@ -478,6 +485,7 @@
         // 다른 기능 버튼의 활성화 클래스 제거
         postManagementButton.classList.remove('active');
         commentManagementButton.classList.remove('active');
+        reportPostManagementButton.classList.remove('active');
         // 현재 기능 버튼에 활성화 클래스 추가
         userManagementButton.classList.add('active');
     });
@@ -486,6 +494,7 @@
         currentPage = 1;
         users = [];
         posts = [];
+        reportposts = [];
         comments = [];
         fetchAndRenderPosts();
         editButton.textContent = '게시글 숨김';
@@ -496,14 +505,36 @@
         // 다른 기능 버튼의 활성화 클래스 제거
         userManagementButton.classList.remove('active');
         commentManagementButton.classList.remove('active');
+        reportPostManagementButton.classList.remove('active');
         // 현재 기능 버튼에 활성화 클래스 추가
         postManagementButton.classList.add('active');
+    });
+
+    reportPostManagementButton.addEventListener('click', () => {
+        currentPage = 1;
+        users = [];
+        posts = [];
+        reportposts = [];
+        comments = [];
+        fetchAndRenderReportPosts();
+        editButton.textContent = '게시글 숨김';
+        deleteButton.textContent = '게시글 삭제';
+        // 권한 수정, 회원 삭제 버튼 표시
+        editButton.style.display = 'block';
+        deleteButton.style.display = 'block';
+        // 다른 기능 버튼의 활성화 클래스 제거
+        userManagementButton.classList.remove('active');
+        commentManagementButton.classList.remove('active');
+        postManagementButton.classList.remove('active');
+        // 현재 기능 버튼에 활성화 클래스 추가
+        reportPostManagementButton.classList.add('active');
     });
 
     commentManagementButton.addEventListener('click', () => {
         currentPage = 1;
         users = [];
         posts = [];
+        reportposts = [];
         comments = [];
         fetchAndRenderComments();
         editButton.textContent = '댓글 숨김';
@@ -514,6 +545,7 @@
         // 다른 기능 버튼의 활성화 클래스 제거
         userManagementButton.classList.remove('active');
         postManagementButton.classList.remove('active');
+        reportPostManagementButton.classList.remove('active');
         // 현재 기능 버튼에 활성화 클래스 추가
         commentManagementButton.classList.add('active');
     });
@@ -528,6 +560,8 @@
                 renderPostsForPage(currentPage);
             } else if (commentManagementButton.classList.contains('active')) {
                 renderCommentsForPage(currentPage);
+            } else if (reportPostManagementButton.classList.contains('active')){
+                renderReportPostsForPage(currentPage);
             }
         }
     });
@@ -657,7 +691,66 @@
                     text: '숨길 게시글을 선택해주세요.',
                 });
             }
-        } else if (commentManagementButton.classList.contains('active')) {
+        } else if (reportPostManagementButton.classList.contains('active')) {
+            const checkedReportPostCheckbox = document.querySelector('.user-checkbox:checked');
+
+            if (checkedReportPostCheckbox) {
+                const oriPostId = checkedReportPostCheckbox.getAttribute('data-oripostId');
+
+                // 게시글 정보를 가져와서 수정 창을 띄우기
+
+                Swal.fire({
+                    title: '게시글을 숨김 처리하시겠습니까?',
+                    text: '되돌릴 수 없습니다.',
+                    icon: 'warning',
+
+                    showCancelButton: true,
+                    confirmButtonColor: '#d33',
+                    cancelButtonColor: '#3085d6',
+                    confirmButtonText: '숨김',
+                    cancelButtonText: '취소',
+
+                    reverseButtons: false, // 버튼 순서 거꾸로
+                }).then(result => {
+                    if (result.isConfirmed) { // 만약 모달창에서 confirm 버튼을 눌렀다면
+                        // 게시글 수정 API 호출
+                        fetch(`/api/posts/${oriPostId}/admin`, {
+                            method: 'PUT',
+                            headers: {
+                                'Authorization': 'Bearer ' + localStorage.getItem('accessToken'),
+                                'Content-Type': 'application/json'
+                            },
+                            body: JSON.stringify({
+                                title: "숨김 처리된 게시글입니다.",
+                                content: "숨김 처리된 게시글입니다.",
+                                completed: false
+                            })
+                        })
+                            .then(response => {
+                                if (!response.ok) {
+                                    throw new Error('Failed to update post');
+                                }
+                                return response.text();
+                            })
+                            .then(responseText => {
+                                Toast.fire({
+                                    icon: 'success',
+                                    title: responseText,
+
+                                })
+                                fetchAndRenderReportPosts();
+                            })
+                            .catch(error => console.error('Error updating post:', error));
+                    }
+                });
+            } else {
+                Swal.fire({
+                    icon: 'warning',
+                    title: '선택 오류',
+                    text: '숨길 게시글을 선택해주세요.',
+                });
+            }
+        }   else if (commentManagementButton.classList.contains('active')) {
             const checkedCommentCheckbox = document.querySelector('.user-checkbox:checked'); // 수정: user-checkbox -> comment-checkbox
 
             if (checkedCommentCheckbox) {
@@ -826,7 +919,61 @@
                     text: '하나의 게시글만 선택해주세요.',
                 });
             }
-        } else if (commentManagementButton.classList.contains('active')) {
+        } else if (reportPostManagementButton.classList.contains('active')) {
+            // 게시글 삭제 기능 추가
+            if (checkedCheckboxes.length === 1) {
+                const oriPostId = checkedCheckboxes[0].getAttribute('data-oriPostId');
+
+                Swal.fire({
+                    title: '게시글을 삭제하시겠습니까?',
+                    text: '되돌릴 수 없습니다.',
+                    icon: 'warning',
+
+                    showCancelButton: true,
+                    confirmButtonColor: '#d33',
+                    cancelButtonColor: '#3085d6',
+                    confirmButtonText: '삭제',
+                    cancelButtonText: '취소',
+
+                    reverseButtons: false, // 버튼 순서 거꾸로
+                }).then(result => {
+                    if (result.isConfirmed) { // 만약 모달창에서 confirm 버튼을 눌렀다면
+                        fetch(`/api/posts/${oriPostId}/admin`, {
+                            method: 'DELETE',
+                            headers: {
+                                'Authorization': 'Bearer ' + localStorage.getItem('accessToken')
+                            }
+                        })
+                            .then(response => {
+                                if (!response.ok) {
+                                    throw new Error('Failed to delete post');
+                                }
+                                return response.text();
+                            })
+                            .then(responseText => {
+                                Toast.fire({
+                                    icon: 'success',
+                                    title: responseText,
+                                })
+                                fetchAndRenderReportPosts();
+                            })
+                            .catch(error => console.error('Error deleting post:', error));
+                    }
+                });
+            } else if (checkedCheckboxes.length === 0) {
+                Swal.fire({
+                    icon: 'warning',
+                    title: '선택 오류',
+                    text: '삭제할 게시글을 선택해주세요.',
+                });
+            } else {
+                Swal.fire({
+                    icon: 'warning',
+                    title: '선택 오류',
+                    text: '하나의 게시글만 선택해주세요.',
+                });
+            }
+        }else if (commentManagementButton.classList.contains('active')) {
             const checkedCommentCheckbox = document.querySelector('.user-checkbox:checked');
 
             if (checkedCommentCheckbox) {
@@ -925,6 +1072,31 @@
             .catch(error => console.error('Error fetching posts:', error));
     }
 
+    function fetchAndRenderReportPosts() {
+        fetch('/api/posts/report', {
+            method: 'GET',
+            headers: {
+                'Authorization': 'Bearer ' + localStorage.getItem('accessToken')
+            }
+        })
+            .then(response => {
+                if (!response.ok) {
+                    throw new Error('Failed to fetch posts');
+                }
+                return response.json();
+            })
+            .then(responsePosts => {
+                reportposts = responsePosts; // 게시물 정보를 저장
+                totalreportPosts = reportposts.length;
+                renderPagination();
+                userInfoList.innerHTML = '';
+                renderReportPostsForPage(currentPage);
+            })
+            .catch(error => console.error('Error fetching posts:', error));
+    }
+
+
+
     function fetchAndRenderComments() {
         fetch('/api/comments', {
             method: 'GET',
@@ -957,6 +1129,8 @@
             totalPages = Math.ceil(posts.length / userPerPage);
         } else if (commentManagementButton.classList.contains('active')) {
             totalPages = Math.ceil(comments.length / userPerPage);
+        } else if (reportPostManagementButton.classList.contains('active')) {
+            totalPages = Math.ceil(reportposts.length / userPerPage);
         }
 
         paginationContainer.innerHTML = '';
@@ -1033,6 +1207,43 @@
             </table>
         `;
             userInfoList.appendChild(postDiv);
+        });
+    }
+
+    function renderReportPostsForPage(page) {
+        const startIndex = (page - 1) * userPerPage;
+        const endIndex = startIndex + userPerPage;
+        const reportPostsToShow = reportposts.slice(startIndex, endIndex);
+
+        userInfoList.innerHTML = '';
+
+        reportPostsToShow.forEach(reportPost => {
+            const reportPostDiv = document.createElement('div');
+            reportPostDiv.classList.add('user-info');
+            reportPostDiv.innerHTML = `
+            <table>
+                <tr>
+                    <td><input type="checkbox" class="user-checkbox" data-reportpostid="${reportPost.id}" data-oripostid="${reportPost.oripostId}"></td>
+                    <td>게시글 작성자 : </td>
+                    <td>${reportPost.username}(${reportPost.nickname})</td>
+                <tr>
+                    <td></td>
+                    <td>게시글 제목 : </td>
+                    <td>${reportPost.title}</td>
+                </tr>
+                <tr>
+                    <td></td>
+                    <td>게시글 내용 : </td>
+                    <td>${reportPost.content.substring(0, 20)}...</td>
+                </tr>
+                <tr>
+                    <td></td>
+                    <td>신고 사유 : </td>
+                    <td>${reportPost.reason.substring(0, 20)}...</td>
+                </tr>
+            </table>
+        `;
+            userInfoList.appendChild(reportPostDiv);
         });
     }
 

--- a/src/main/resources/templates/post.html
+++ b/src/main/resources/templates/post.html
@@ -14,7 +14,10 @@
     <link crossorigin="anonymous" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0/dist/css/bootstrap.min.css"
           integrity="sha384-gH2yIJqKdNHPEq0n4Mqa/HGKIhSkIHeL5AyhkYV8i59U5AR6csBvApHHNl/vI1Bx" rel="stylesheet">
     <script crossorigin="anonymous" integrity="sha384-A3rJD856KowSb7dwlZdYEkO39Gagi7vIsF0jrRAoQmDKKtQBHUuLZ9AsSv4jD4Xa"
-            src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0/dist/js/bootstrap.bundle.min.js">
+            src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0/dist/js/bootstrap.bundle.min.js">function openReportModal() {
+
+    }
+
     </script>
 
     <script src="https://cdn.jsdelivr.net/npm/js-cookie@3.0.5/dist/js.cookie.min.js"></script>
@@ -146,6 +149,22 @@
             </div>
         </div>
 
+        <!-- 모달 창 -->
+        <div id="reportModal" class="modal">
+            <div class="modal-content">
+                <span class="close" onclick="closeReportModal()">&times;</span>
+                <h2>게시물 신고</h2>
+                <form id="reportForm">
+                    <label for="reason">신고 사유:</label>
+                    <textarea id="reason" name="reason" rows="4" required></textarea>
+                    <div class="modal-buttons">
+                        <button type="button" onclick="reportPost()">확인</button>
+                        <button type="button" onclick="closeReportModal()">취소</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+
         <div class="comment-content">
             <div class="comment">
                 <h4>댓글</h4>
@@ -156,6 +175,10 @@
                                placeholder="댓글을 입력하세요">
                     </div>
                     <button type="submit" class="submit-button">댓글 작성</button>
+                    <!-- 신고 아이콘 추가 -->
+                    <a href="#" class="report-button" onclick="openReportModal()">
+                        <img src="https://img.icons8.com/plasticine/72/000000/siren.png" alt="신고 아이콘">
+                    </a>
                 </form>
                 <div class="line"></div>
                 <!-- 댓글 목록 출력 -->
@@ -214,6 +237,60 @@
     function gotoMain() {
         window.location.href = "/main";
     }
+
+    // 모달 창 열기
+    function openReportModal() {
+        var modal = document.getElementById("reportModal");
+        modal.style.display = "block";
+    }
+
+    // 모달 창 닫기
+    function closeReportModal() {
+        var modal = document.getElementById("reportModal");
+        modal.style.display = "none";
+    }
+
+    // 게시물 신고 요청 보내기
+    function reportPost() {
+        var reason = document.getElementById("reason").value;
+        const postId = window.location.href.split('/').pop();
+
+        if (reason.trim() === "") {
+            alert("신고 사유를 입력하세요.");
+            return;
+        }
+
+        // API 호출 코드 추가
+        fetch(`/api/posts/report/${postId}`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ reason: reason }),
+        })
+            .then(response => {
+                if (response.status === 200) {
+                    response.text().then(data => {
+                        alert(data); // 서버에서 반환한 메시지를 알림으로 표시
+                        if (data === "게시글이 신고되었습니다.") {
+                            // closeReportModal(); // 모달 창 닫기
+                        }
+                    });
+                } else {
+                    response.text().then(data => {
+                        alert(data); // 서버에서 반환한 오류 메시지를 알림으로 표시
+                    });
+                }
+            })
+            .catch(error => {
+                console.error('Error:', error);
+                alert('신고 중 오류가 발생했습니다.');
+            })
+            .finally(() => {
+            closeReportModal(); // 모달 창 닫기
+        });
+    }
+
 
     // 게시물 삭제 함수
     function deletePost() {


### PR DESCRIPTION
## 바꾼 이유
- 신고 관리탭 추가 (어드민 페이지)
- 신고 기능 추가 : 신고 기능을 추가(게시글 상세조회) , 신고된 게시글 관리 가능(어드민 페이지)
- 신고 범위 수정 : 본인의 게시글 신고 불가, 관리자는 신고 불가
- post에 연관관계 추가 (게시글이 신고되있어도 게시글 삭제 가능하도록)
- 리팩토링 : entity에 type을 추가하여 DB에서 구분 가능하도록 코드수정
- 리팩토링 : 알림 아이콘 수정


## 주요 변화
- REPORT관련 클래스 파일 추가
- Notification에 type 컬럼 추가
- 알림 아이콘 수정 / 댓글알림 : 🔔 / 신고알림 : 🚨 / 프로젝트 유저참여 알림 : 🤗 / 프로젝트 마감 알림 : ⏳
- post entity에 reportList 추가 
- 게시글 상세조회시 신고버튼 추가
- 본인의 게시글 신고 불가, 관리자는 신고 불가
- 어드민 페이지에 신고관리탭 추가(숨김, 삭제 가능)

## 전달 사항
- 테스트 완료했습니다. 추가적인 오류 발견하면 추가수정하도록 하겠습니다.