### PR TITLE
HTML 파일 수정

### DIFF
--- a/src/main/java/com/sangbu3jo/elephant/chat/dto/ChatMessageResponseDto.java
+++ b/src/main/java/com/sangbu3jo/elephant/chat/dto/ChatMessageResponseDto.java
@@ -15,6 +15,7 @@ public class ChatMessageResponseDto {
     private String username; // 서버와 통신용
     private String message;
     private LocalDateTime sendTime;
+    private String url;
 
     public ChatMessageResponseDto(ChatMessage chatMessage) {
         this.type = chatMessage.getType();
@@ -23,6 +24,10 @@ public class ChatMessageResponseDto {
         this.username = chatMessage.getUser().getUsername();
         this.message = chatMessage.getMessage();
         this.sendTime = chatMessage.getSendTime();
+    }
+
+    public void updateUrl(String url) {
+        this.url = url;
     }
 
 }

--- a/src/main/java/com/sangbu3jo/elephant/chat/dto/PrivateChatMessageResponseDto.java
+++ b/src/main/java/com/sangbu3jo/elephant/chat/dto/PrivateChatMessageResponseDto.java
@@ -15,6 +15,7 @@ public class PrivateChatMessageResponseDto {
     private String username; // 서버와 통신용
     private String message;
     private LocalDateTime sendTime;
+    private String url;
 
     public PrivateChatMessageResponseDto (PrivateChatMessage privateChatMessage) {
         this.type = privateChatMessage.getType();
@@ -23,6 +24,10 @@ public class PrivateChatMessageResponseDto {
         this.username = privateChatMessage.getUser().getUsername();
         this.message = privateChatMessage.getMessage();
         this.sendTime = privateChatMessage.getSendTime();
+    }
+
+    public void updateUrl(String url) {
+        this.url = url;
     }
 
 }

--- a/src/main/java/com/sangbu3jo/elephant/chat/dto/PrivateChatRoomResponseDto.java
+++ b/src/main/java/com/sangbu3jo/elephant/chat/dto/PrivateChatRoomResponseDto.java
@@ -26,10 +26,11 @@ public class PrivateChatRoomResponseDto {
         this.title = privateChatRoom.getTitle();
         // username과 동일하면 다른 사람을 showUser에 담아서 반환하도록 함
         this.showUser = setPrivateChatTitle(username, privateChatRoom);
-        this.time = privateChatMessage.getSendTime();
 
         // 최근 메세지 내역이 있으면 그 내용을 보여줌
         if (privateChatMessage != null) {
+            this.time = privateChatMessage.getSendTime();
+
             String message = privateChatMessage.getMessage();
             if (message.length() > 20) {
                 this.message = message.substring(0, 20) + "...";

--- a/src/main/java/com/sangbu3jo/elephant/email/service/EmailCheckServiceImpl.java
+++ b/src/main/java/com/sangbu3jo/elephant/email/service/EmailCheckServiceImpl.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -30,7 +31,11 @@ public class EmailCheckServiceImpl implements EmailCheckService {
   @Override
   @Async
   public ResponseEntity<String> sendEmail(String userEmail) throws Exception {
-    isExistUsername(userEmail);
+    try {
+      isExistUsername(userEmail);
+    } catch (IllegalArgumentException e) {
+      return ResponseEntity.badRequest().body(e.getMessage());
+    }
 
     String password = UUID.randomUUID().toString();
     saveEmailPassword(userEmail, password);
@@ -40,7 +45,6 @@ public class EmailCheckServiceImpl implements EmailCheckService {
       return ResponseEntity.ok("이메일 전송 성공");
     } catch (MailException e) {
       e.printStackTrace();
-//      throw new Exception("메일 보내는 도중 오류 발생");
       return ResponseEntity.badRequest().body("메일 보내는 도중 오류 발생");
     }
   }

--- a/src/main/java/com/sangbu3jo/elephant/email/service/EmailCheckServiceImpl.java
+++ b/src/main/java/com/sangbu3jo/elephant/email/service/EmailCheckServiceImpl.java
@@ -40,7 +40,8 @@ public class EmailCheckServiceImpl implements EmailCheckService {
       return ResponseEntity.ok("이메일 전송 성공");
     } catch (MailException e) {
       e.printStackTrace();
-      throw new Exception("메일 보내는 도중 오류 발생");
+//      throw new Exception("메일 보내는 도중 오류 발생");
+      return ResponseEntity.badRequest().body("메일 보내는 도중 오류 발생");
     }
   }
 

--- a/src/main/resources/static/css/backUsers.css
+++ b/src/main/resources/static/css/backUsers.css
@@ -23,6 +23,12 @@ html, body {
     align-items: center; /* 세로 가운데 정렬 추가 */
 }
 
+mb-3 {
+    width: 100%;
+    height: 40vh;
+    margin: 0 !important;
+}
+
 /* 상단 메뉴 */
 .top {
     color: white;
@@ -269,10 +275,33 @@ a:hover {
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
     border-radius: 5px;
     display: flex;
+    flex-direction: column;
     align-items: center;
     margin: 5px 0;
-    width: 90%;
+    width: 95%;
 }
+
+.user-info2 {
+    background-color: transparent;
+    border-radius: 5px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin: 5px 0;
+    width: 100%;
+}
+
+.col-md-4{
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 10px;
+}
+
+#upload-image-button {
+    padding: 0;
+}
+
 
 /* 수정 및 삭제 버튼 스타일 */
 .edit-delete-buttons{
@@ -296,13 +325,14 @@ a:hover {
 
 .user-info-list {
     display: flex;
-    flex-direction: column; /* 항목을 수직으로 쌓습니다 */
-    max-height: 90vh; /* 컨텐츠의 최대 높이 설정 */
-    overflow-y: auto; /* 컨텐츠가 넘칠 때 수직 스크롤바를 추가합니다 */
+    flex-direction: column;
+    max-height: 90vh;
+    overflow-y: auto;
+    overflow-x: hidden;
     gap: 10px;
-    width: 90%; /* 건욱님 코드는 80%*/
-    justify-content: flex-start; /* 요소들을 왼쪽 정렬로 유지 */
-    align-items: flex-start; /* 요소들을 위쪽 정렬로 유지 */
+    width: 90%;
+    justify-content: flex-start;
+    align-items: flex-start;
 }
 
 .user-info-list::-webkit-scrollbar {

--- a/src/main/resources/static/css/cardCalendar.css
+++ b/src/main/resources/static/css/cardCalendar.css
@@ -71,7 +71,7 @@ html, body {
 .title1{
     width: 50%;
     height: 100%;
-    font-size: 20px;
+    font-size: 22px;
     font-weight: bold;
     display: flex;
     align-items: center;
@@ -93,7 +93,7 @@ html, body {
 .bottom {
     height: 90%;
     width: 100%;
-    padding: 5px;
+    padding: 0px;
     background-color: transparent;
     text-align: center;
     display: flex;
@@ -132,6 +132,11 @@ html, body {
 
 .custom-event{
     cursor: pointer;
-    background-color: #4942E4;
+    background-color: #a6a2ff;
     border: none;
+    padding: 0px 3px;
+}
+
+.fc-h-event{
+    border: 1px solid #a6a2ff;
 }

--- a/src/main/resources/static/css/login.css
+++ b/src/main/resources/static/css/login.css
@@ -230,6 +230,26 @@ body {
     width: 100%;
 }
 
+#timer , #timerValue {
+    font-size: 14px;
+}
+
+.inputs{
+    background-color: #fff;
+    border: none;
+    padding: 0.9rem 0.9rem;
+    margin: 0.5rem 0;
+    width: 90%;
+}
+
+.modal {
+    width: 100%;
+}
+
+#check-email-btn{
+    
+}
+
 @keyframes show {
     0%,
     49.99% {
@@ -260,6 +280,16 @@ a.list-group-item .vs-title {
 }
 .social a {
     text-decoration: none;
+}
+
+a {
+    color: black;
+    text-underline: none;
+    text-decoration: none;
+}
+
+a:hover{
+    color: #002cc4;
 }
 
 #login-kakao-btn {

--- a/src/main/resources/static/js/login.js
+++ b/src/main/resources/static/js/login.js
@@ -170,28 +170,69 @@ function signup() {
   });
 }
 
+var modal = document.getElementById('emailModal');
+var timerValue = document.getElementById('timerValue');
+var timerIntervalId;
 
 
 // 인증메일 전송 버튼 클릭 시
 function sendEmail() {
   // 서버로 인증번호 전송 요청하기.
   let userEmail = $('#username').val();
-  console.log('email: ' + userEmail);
+  var modal = $('.modal');
+  modal.css('display', 'block');
 
   $.ajax({
     type: "GET",
     url: `/api/auth/email/${userEmail}/invited`,
     success: function (data) {
-      console.log(data);
+      startTimer(5 * 60); // 5분 타이머 시작 (5분 = 5 * 60초)
+      console.log('email: ' + userEmail);
     },
-    error: function (error) {
+    error: function (error, response, xhr) {
       console.error("이메일 전송 실패");
+      console.log(response);
+      modal.css('display', 'none');
+      if (xhr.responseText == "메일 보내는 도중 오류 발생") {
+        Toast.fire({
+          icon: 'error',
+          title: '이메일 전송 오류'
+        })
+      } else {
+        Toast.fire({
+          icon: 'error',
+          title: '이미 가입된 이메일입니다'
+        })
+      }
     }
   });
 }
 
+function startTimer(duration) {
+  var timer = duration;
+  var minutes, seconds;
+
+  timerIntervalId = setInterval(function () {
+    minutes = parseInt(timer / 60, 10);
+    seconds = parseInt(timer % 60, 10);
+
+    minutes = minutes < 10 ? "0" + minutes : minutes;
+    seconds = seconds < 10 ? "0" + seconds : seconds;
+
+    timerValue.textContent = minutes + ":" + seconds;
+
+    if (--timer < 0) {
+      clearInterval(timerIntervalId);
+      timerValue.textContent = "시간 초과!";
+      // 타이머 종료 후 원하는 작업을 수행하세요.
+    }
+  }, 1000);
+}
+
 
 function checkEmail() {
+  clearInterval(timerIntervalId); // 타이머 종료
+
   // 인증 여부 저장할 hidden
   var checkBox = document.getElementById("email-check");
   // 사용자가 입력한 인증 번호

--- a/src/main/resources/templates/backUsers.html
+++ b/src/main/resources/templates/backUsers.html
@@ -176,6 +176,7 @@
     // header js 코드 추가
     $(document).ready(function () {
         pageSetting();
+        fetchAndRenderUsers();
 
         const notificationIcon = document.querySelector('.notification-icon');
         const notificationBadge = document.getElementById('notificationBadge');
@@ -1224,94 +1225,69 @@
         userInfoList.innerHTML = '';
 
         const userDiv = document.createElement('div');
-        userDiv.classList.add('user-info');
+        userDiv.classList.add('user-info2');
 
         const username = usersToShow.username;
-        const password = usersToShow.password;
         const nickname = usersToShow.nickname;
         const introduction = usersToShow.introduction;
         const profileUrl = usersToShow.profileUrl;
 
-
-        // 비밀번호를 최대 8자리까지 '*' 문자로 표시
-        const maskedPassword = usersToShow.password.length > 8 ? '*'.repeat(8) : '*'.repeat(
-            usersToShow.password.length);
-
         userDiv.innerHTML = `
-
-
             <table>
-                <tr>
-                    <td>유저 아이디 : </td>
-                    <td>${usersToShow.username}</td>
-                </tr>
-                <tr>
-                    <td>비밀번호 : </td>
-                    <td>${maskedPassword}</td>
-                </tr>
-                <tr>
-                    <td>닉네임 : </td>
-                    <td>${usersToShow.nickname}</td>
-                </tr>
-                <tr>
-                    <td>자기소개 : </td>
-                    <td>${usersToShow.introduction}</td>
-                </tr>
-                 <tr>
-                    <td>프로필 이미지 : </td>
-                    <td><img src="${usersToShow.profileUrl}" alt="프로필 이미지"  style="width: 100px; height: 100px;" ></td>
-
-                  </tr>
-
-                  <tr>
-                  <td><input type="file" id="image-input" accept="image/*"></td>
-                  </tr>
-                  <tr>
-                  <td><button id="upload-image-button">이미지 변경 Go</button></td>
-                  </tr>
+                <tbody>
+                    <div class="card mb-3" style="max-width: 540px;">
+                        <div class="row g-0">
+                            <div class="col-md-4">
+                                <img src="${profileUrl}" class="img-fluid rounded-start" alt="Profile Image">
+                            </div>
+                            <div class="col-md-8">
+                                <div class="card-body">
+                                    <h4 class="card-title">${username}</h4>
+                                    <h5 class="card-text">Nickname: ${nickname}</h5>
+                                    <h5 class="card-text">Introduction: ${introduction}</h5>
+                                </div>
+                                <div class="card-body">
+                                    <input type="file" id="image-input" accept="image/*">
+                                    <button id="upload-image-button">프로필 사진 변경</button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </tbody>
             </table>
-
-         `;
-
-            const uploadImageButton = userDiv.querySelector('#upload-image-button');
-            const profileImage = userDiv.querySelector('#profile-image');
-            const imageInput = userDiv.querySelector('#image-input');
-
-            // 프로필 이미지 업로드 버튼에 클릭 이벤트를 추가하고 이미지를 선택하면 AJAX를 통해 서버로 업로드
-            uploadImageButton.addEventListener('click', () => {
-                const file = imageInput.files[0];
-
-
-                if (file) {
-                    const formData = new FormData();
-                    formData.append('image', file);
-
-                    // AJAX 요청을 보내고 이미지 URL을 서버로 업로드
-                    $.ajax({
-                        url: '/api/users/profile/image', // 서버 업로드 URL로 변경
-                        type: 'POST',
-                        data: formData,
-                        contentType: false,
-                        processData: false,
-                        success: function (data) {
-                            // 서버에서 응답을 받은 후 처리할 로직을 여기에 추가
-                            // data는 서버에서 받은 응답 데이터입니다.
-
-                            location.reload();
-
-                        },
-                        error: function (error) {
-                            console.error('업로드 실패:', error);
-                        }
-                    });
-                }
-
-
-
-        });
-
+        `;
 
         userInfoList.appendChild(userDiv);
+        const uploadImageButton = userDiv.querySelector('#upload-image-button');
+        const profileImage = userDiv.querySelector('#profile-image');
+        const imageInput = userDiv.querySelector('#image-input');
+
+        // 프로필 이미지 업로드 버튼에 클릭 이벤트를 추가하고 이미지를 선택하면 AJAX를 통해 서버로 업로드
+        uploadImageButton.addEventListener('click', () => {
+            const file = imageInput.files[0];
+
+            if (file) {
+                const formData = new FormData();
+                formData.append('image', file);
+
+                // AJAX 요청을 보내고 이미지 URL을 서버로 업로드
+                $.ajax({
+                    url: '/api/users/profile/image', // 서버 업로드 URL로 변경
+                    type: 'POST',
+                    data: formData,
+                    contentType: false,
+                    processData: false,
+                    success: function (data) {
+                        // 서버에서 응답을 받은 후 처리할 로직을 여기에 추가
+                        // data는 서버에서 받은 응답 데이터입니다.
+                        location.reload();
+                    },
+                    error: function (error) {
+                        console.error('업로드 실패:', error);
+                    }
+                });
+            }
+        });
     }
 
 

--- a/src/main/resources/templates/board.html
+++ b/src/main/resources/templates/board.html
@@ -58,6 +58,40 @@
         </div>
         <!--프로젝트 떠나기 모달창 종료-->
 
+        <button class="btn btn-light updateBtn" data-bs-toggle="modal" type="button" th:data-bs-target="'#boardBack'+${board.id}"> 프로젝트 수정 </button>
+
+        <!--수정 모달창 -->
+        <div class="modal fade" th:id="'boardBack'+${board.id}" aria-labelledby="exampleModalLabell" aria-hidden="true">
+            <div class="modal-dialog modal-dialog-centered">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h1 class="modal-title fs-5" id="exampleM">프로젝트 수정</h1>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <div class="modal-body">
+                        <div class="mb-3">
+                            <label for="recipient-name" class="col-form-label">프로젝트 이름</label>
+                            <input type="text" class="form-control recipient-namee" id="recipient-name" th:value="${board.title}">
+                        </div>
+                        <div class="mb-3">
+                            <label for="message-text" class="col-form-label">프로젝트 설명</label>
+                            <textarea class="form-control message-textt" id="message-text" th:text="${board.content}"></textarea>
+                        </div>
+                        <div class="mb-3">
+                            <label for="datepickerr" class="col-form-label">프로젝트 마감일</label>
+                            <input type="text" class="form-control datepickerr" id="datepickerr" th:placeholder="${board.expiredAt}"
+                                   data-date-settings='{"format": "yyyy-mm-dd"}'>
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-light btn-update" th:id="${board.id}">수정</button>
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">취소</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <!--수정 모달창 종료-->
+
         <!-- 참여자 목록 -->
         <button class="btn btn-light dropdown-toggle" type="button" id="toggleListButton"
                 data-bs-toggle="dropdown" aria-expanded="false"> 사용자 목록 </button>
@@ -111,6 +145,9 @@
                 </h5>
                 <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
             </div>
+
+            <div class="offcanvas-header" style = "align-items:center; color: #1a1515; font-size: 15px; padding-bottom: 0px;" th:text="|마감일: ${board.expiredAt}|"></div>
+            <div class="offcanvas-header" style = "align-items:center; color: #1a1515; font-size: 15px; padding-top: 0px;" th:text="${board.content}"></div>
 
             <div class="list-group list-group-flush">
                 <a class="list-group-item list-group-item-action" id="leaveButton" data-bs-toggle="modal" th:data-bs-target="'#leaveboard'+${board.id}" >프로젝트 떠나기</a>
@@ -238,6 +275,43 @@
             toast.addEventListener('mouseenter', Swal.stopTimer)
             toast.addEventListener('mouseleave', Swal.resumeTimer)
         }
+    })
+
+    const updateProject = document.querySelector(".btn-update");
+    updateProject.addEventListener('click', () => {
+        const id = updateProject.id;
+        console.log(id); // 가져온 board의 id 값 확인
+
+        $(`#boardBack${id}`).modal('hide');
+
+        const modal = updateProject.closest('.modal-content'); // 클릭한 버튼이 속한 모달을 선택
+
+        const title = modal.querySelector(".recipient-namee").value;
+        const content = modal.querySelector(".message-textt").value;
+        const expiredAt = modal.querySelector(".datepickerr").value;
+
+        console.log("수정된 프로젝트 이름:", title);
+        console.log("수정된 프로젝트 설명:", content);
+        console.log("수정된 프로젝트 마감일:", expiredAt);
+        console.log("수정될 프로젝트 아이디: ", id);
+
+
+        $.ajax({
+            method: "PUT",
+            url: `/api/boards/${id}`,
+            contentType: "application/json",
+            data: JSON.stringify({
+                title : title,
+                content : content,
+                expiredAt : expiredAt
+            }),
+            success: function (data) {
+                window.location.reload();
+            },
+            error: function (data) {
+
+            }
+        })
     })
 
     $(document).ready(function () {

--- a/src/main/resources/templates/chat.html
+++ b/src/main/resources/templates/chat.html
@@ -117,160 +117,94 @@
             url : "/api/chat/messages/" + id,
             contentType : 'application/json',
             success: function (data) {
-                console.log(data);
-                var chatting = data;
+                if (data != null && data !== "") {
+                    var chatting = data;
 
-                chatting.forEach(function (chatItem) {
-                    var messageElement = document.createElement('li');
-                    if(chatItem.type === 'ENTER') {
-                        messageElement.classList.add('event-message');
-                        chatItem.content = chatItem.username + chatItem.message;
-                    } else if (chatItem.type === 'LEAVE') {
-                        messageElement.classList.add('event-message');
-                        chatItem.content = chatItem.username + chatItem.message;
-                    } else {
-                        var avatarElement = document.createElement('i');
-                        var usernameElement = document.createElement('span');
-                        messageElement.classList.add(chatItem.username === username ? 'chat-message2' : 'chat-message');
-                        avatarElement.style['background-color'] = getAvatarColor(chatItem.nickname);
-                        avatarElement.appendChild(document.createTextNode(chatItem.nickname[0]));
-                        usernameElement.appendChild(document.createTextNode(chatItem.nickname));
-                        messageElement.appendChild(avatarElement);
-                        messageElement.appendChild(usernameElement);
-                    }
+                    chatting.forEach(function (chatItem) {
+                        var messageElement = document.createElement('li');
+                        if(chatItem.type === 'ENTER') {
+                            messageElement.classList.add('event-message');
+                            chatItem.content = chatItem.username + chatItem.message;
+                        } else if (chatItem.type === 'LEAVE') {
+                            messageElement.classList.add('event-message');
+                            chatItem.content = chatItem.username + chatItem.message;
+                        } else {
+                            var avatarElement = document.createElement('i');
+                            var usernameElement = document.createElement('span');
+                            messageElement.classList.add(chatItem.username === username ? 'chat-message2' : 'chat-message');
 
-                    var textElement = document.createElement('p');
-                    var messageText = document.createTextNode(chatItem.message);
-                    textElement.appendChild(messageText);
+                            if (chatItem.url != null) {
+                                avatarElement.style['background-image'] = 'url(' + chatItem.url + ')';
+                                avatarElement.style['background-size'] = 'cover';
+                            } else {
+                                avatarElement.style['background-image'] = 'url(https://cdn-icons-png.flaticon.com/128/1864/1864497.png)';
+                                avatarElement.style['background-size'] = 'cover';
+                            }
+                            usernameElement.appendChild(document.createTextNode(chatItem.nickname));
+                            messageElement.appendChild(avatarElement);
+                            messageElement.appendChild(usernameElement);
+                        }
 
-                    messageElement.appendChild(textElement);
+                        var textElement = document.createElement('p');
+                        var messageText = document.createTextNode(chatItem.message);
+                        textElement.appendChild(messageText);
 
-                    messageArea.appendChild(messageElement);
-                });
+                        messageElement.appendChild(textElement);
 
-                messageArea.scrollTop = messageArea.scrollHeight;
+                        messageArea.appendChild(messageElement);
+                    });
+
+                    messageArea.scrollTop = messageArea.scrollHeight;
+                }
+
             }
         })
     }
 
     function onMessageReceived(payload) {
         var chat = JSON.parse(payload.body);
+        console.log(chat);
 
-        console.log(chat.type); // 이 콘솔 찍히는거 확인함 (Enter의 경우)
+        var messageElement = document.createElement('li');
 
-        if (Array.isArray(chat)) {
-            chat.forEach(function (chatItem) {
-                var messageElement = document.createElement('li');
-                if (chatItem.username === username) {
-                    console.log(chatItem.nickname);
-                    messageElement.classList.add('chat-message2');
-
-                    var avatarElement = document.createElement('i');
-                    var avatarText = document.createTextNode(chatItem.nickname[0]);
-                    avatarElement.appendChild(avatarText);
-                    avatarElement.style['background-color'] = getAvatarColor(chatItem.nickname);
-
-                    var avatarElement = document.createElement('i');
-                    var avatarText = document.createTextNode(chatItem.nickname[0]);
-                    avatarElement.appendChild(avatarText);
-                    avatarElement.style['background-color'] = getAvatarColor(chatItem.nickname);
-
-                    messageElement.appendChild(avatarElement);
-
-                    var usernameElement = document.createElement('span');
-                    var usernameText = document.createTextNode(chatItem.nickname);
-                    usernameElement.appendChild(usernameText);
-                    messageElement.appendChild(usernameElement);
-                } else {
-                    console.log(chatItem.nickname);
-                    messageElement.classList.add('chat-message');
-
-                    var avatarElement = document.createElement('i');
-                    var avatarText = document.createTextNode(chatItem.nickname[0]);
-                    avatarElement.appendChild(avatarText);
-                    avatarElement.style['background-color'] = getAvatarColor(chatItem.nickname);
-
-                    var avatarElement = document.createElement('i');
-                    var avatarText = document.createTextNode(chatItem.nickname[0]);
-                    avatarElement.appendChild(avatarText);
-                    avatarElement.style['background-color'] = getAvatarColor(chatItem.nickname);
-
-                    messageElement.appendChild(avatarElement);
-
-                    var usernameElement = document.createElement('span');
-                    var usernameText = document.createTextNode(chatItem.nickname);
-                    usernameElement.appendChild(usernameText);
-                    messageElement.appendChild(usernameElement);
-                }
-                var textElement = document.createElement('p');
-                var messageText = document.createTextNode(chatItem.message);
-                textElement.appendChild(messageText);
-
-                messageElement.appendChild(textElement);
-
-                messageArea.appendChild(messageElement);
-                messageArea.scrollTop = messageArea.scrollHeight;
-            });
-        } else {
-            var messageElement = document.createElement('li');
-            if(chat.type === 'ENTER') {
-                messageElement.classList.add('event-message');
-                chat.content = chat.username + chat.message;
-            } else if (chat.type === 'LEAVE') {
-                messageElement.classList.add('event-message');
-                chat.content = chat.username + chat.message;
-            } else {
-                if (chat.username === username) {
-                    messageElement.classList.add('chat-message2');
-
-                    var avatarElement = document.createElement('i');
-                    var avatarText = document.createTextNode(chat.nickname[0]);
-                    avatarElement.appendChild(avatarText);
-                    avatarElement.style['background-color'] = getAvatarColor(chat.nickname);
-
-                    var avatarElement = document.createElement('i');
-                    var avatarText = document.createTextNode(chat.nickname[0]);
-                    avatarElement.appendChild(avatarText);
-                    avatarElement.style['background-color'] = getAvatarColor(chat.nickname);
-
-                    messageElement.appendChild(avatarElement);
-
-                    var usernameElement = document.createElement('span');
-                    var usernameText = document.createTextNode(chat.nickname);
-                    usernameElement.appendChild(usernameText);
-                    messageElement.appendChild(usernameElement);
-                } else {
-                    messageElement.classList.add('chat-message');
-
-                    var avatarElement = document.createElement('i');
-                    var avatarText = document.createTextNode(chat.nickname[0]);
-                    avatarElement.appendChild(avatarText);
-                    avatarElement.style['background-color'] = getAvatarColor(chat.nickname);
-
-                    var avatarElement = document.createElement('i');
-                    var avatarText = document.createTextNode(chat.nickname[0]);
-                    avatarElement.appendChild(avatarText);
-                    avatarElement.style['background-color'] = getAvatarColor(chat.nickname);
-
-                    messageElement.appendChild(avatarElement);
-
-                    var usernameElement = document.createElement('span');
-                    var usernameText = document.createTextNode(chat.nickname);
-                    usernameElement.appendChild(usernameText);
-                    messageElement.appendChild(usernameElement);
-                }
-            }
-
+        if(chat.type === 'ENTER') {
+            console.log(chat.type);
+            messageElement.classList.add('event-message');
+            chat.content = chat.username + chat.message;
             var textElement = document.createElement('p');
             var messageText = document.createTextNode(chat.message);
             textElement.appendChild(messageText);
+            messageElement.appendChild(textElement);
+            messageArea.appendChild(messageElement);
+            messageArea.scrollTop = messageArea.scrollHeight;
+        } else if (chat.type === 'LEAVE') {
+            messageElement.classList.add('event-message');
+            chat.content = chat.username + chat.message;
+        } else {
+            var avatarElement = document.createElement('i');
+            var usernameElement = document.createElement('span');
+            var textElement = document.createElement('p');
 
+            messageElement.classList.add(chat.username === username ? 'chat-message2' : 'chat-message');
+            if (chat.url != null) {
+                avatarElement.style['background-image'] = 'url(' + chat.url + ')';
+                avatarElement.style['background-size'] = 'cover';
+            } else {
+                avatarElement.style['background-image'] = 'url(https://cdn-icons-png.flaticon.com/128/1864/1864497.png)';
+                avatarElement.style['background-size'] = 'cover';
+            }
+
+            console.log(chat.message);
+            usernameElement.appendChild(document.createTextNode(chat.nickname));
+            textElement.appendChild(document.createTextNode(chat.message));
+
+            messageElement.appendChild(avatarElement);
+            messageElement.appendChild(usernameElement);
             messageElement.appendChild(textElement);
 
             messageArea.appendChild(messageElement);
             messageArea.scrollTop = messageArea.scrollHeight;
         }
-
     }
 
     // usernameForm이 동작할 때 connect가 동작하도록 되어있으니

--- a/src/main/resources/templates/login-page.html
+++ b/src/main/resources/templates/login-page.html
@@ -42,20 +42,19 @@
             <!--인증 여부 값 hidden-->
             <input id="email-check" type="hidden" name="emailCheck" value="false" style="display:none">
 
-            <a href="#" id="sendEmail" style="
-            margin-left: -53%;
+            <a href="#" id="sendEmail" style="margin-left: -60%;
             font-size:14px;" onclick="sendEmail()">이메일 인증번호 보내기</a>
-            <div class="modal" style="margin-left:-17%;
-            margin-top:5px;">
+            <div class="modal" style="margin-top:5px; display: none;">
                 <div class="modal-content">
                     <!-- 모달 내용 -->
-                    <input type="text" id="email-password" name="email-password" placeholder="5분 이내 입력 부탁드립니다.">
+                    <input class="inputs" type="text" id="email-password" name="email-password" placeholder="5분 이내 입력 부탁드립니다.">
+                    <span id="timer">남은 시간: <span id="timerValue">05:00</span></span>
                     <button id="check-email-btn" onclick="checkEmail()">인증하기</button>
                 </div>
             </div>
 
             <input type="password" placeholder="비밀번호" name="password" id="password" class="input"/>
-            <a href="" id="showSignupPwBtn" style="margin-left: -70%; font-size:14px;">비밀번호 보기</a>
+            <a href="" id="showSignupPwBtn" style="margin-left: -80%; font-size:14px;">비밀번호 보기</a>
             <input type="text" placeholder="닉네임" name="nickname" id="nickname" class="input"/>
             <input type="text" placeholder="자기소개" name="introduce" id="introduce" class="input"/>
             <input id="admin-check" type="checkbox" name="admin" onclick="onclickAdmin()" style="margin-top: 10px;">관리자
@@ -72,7 +71,7 @@
             <input type="text" placeholder="아이디" name="loginUsername" id="loginUsername" class="input"/>
             <input type="password" placeholder="비밀번호" name="loginPassword" id="loginPassword"
                    class="input"/>
-            <a href="" id="showLoginPwBtn" style="margin-left: -70%; font-size:14px;">비밀번호 보기</a>
+            <a href="" id="showLoginPwBtn" style="margin-left: -80%; font-size:14px;">비밀번호 보기</a>
             <button class="btn" onclick="onLogin()">로그인하기</button>
             <button id="login-kakao-btn"
                     onclick="location.href='https://kauth.kakao.com/oauth/authorize?client_id=d7da621a3b256dc1ef5cc2ee72d98307&redirect_uri=http://localhost:8080/api/auth/kakao/callback&response_type=code'">

--- a/src/main/resources/templates/privateChat.html
+++ b/src/main/resources/templates/privateChat.html
@@ -159,14 +159,22 @@
                 var chatting = data;
 
                 chatting.forEach(function (chatItem) {
+                    console.log(chatItem.url);
                     var messageElement = document.createElement('li');
                     var avatarElement = document.createElement('i');
                     var usernameElement = document.createElement('span');
                     var textElement = document.createElement('p');
 
                     messageElement.classList.add(chatItem.username === username ? 'chat-message2' : 'chat-message');
-                    avatarElement.style['background-color'] = getAvatarColor(chatItem.nickname);
-                    avatarElement.appendChild(document.createTextNode(chatItem.nickname[0]));
+
+                    if (chatItem.url != null) {
+                        avatarElement.style['background-image'] = 'url(' + chatItem.url + ')';
+                        avatarElement.style['background-size'] = 'cover';
+                    } else {
+                        avatarElement.style['background-image'] = 'url(https://cdn-icons-png.flaticon.com/128/1864/1864497.png)';
+                        avatarElement.style['background-size'] = 'cover';
+                    }
+
                     usernameElement.appendChild(document.createTextNode(chatItem.nickname));
                     textElement.appendChild(document.createTextNode(chatItem.message));
 
@@ -202,8 +210,13 @@
                 var textElement = document.createElement('p');
 
                 messageElement.classList.add(chat.username === username ? 'chat-message2' : 'chat-message');
-                avatarElement.style['background-color'] = getAvatarColor(chat.nickname);
-                avatarElement.appendChild(document.createTextNode(chat.nickname[0]));
+                if (chat.url != null) {
+                    avatarElement.style['background-image'] = 'url(' + chat.url + ')';
+                    avatarElement.style['background-size'] = 'cover';
+                } else {
+                    avatarElement.style['background-image'] = 'url(https://cdn-icons-png.flaticon.com/128/1864/1864497.png)';
+                    avatarElement.style['background-size'] = 'cover';
+                }
                 usernameElement.appendChild(document.createTextNode(chat.nickname));
                 textElement.appendChild(document.createTextNode(chat.message));
 


### PR DESCRIPTION
## 바꾼 이유
- 보이는 화면을 사용하기 편하게 전반적으로 수정했습니다.

## 주요 변화
- 채팅방 프로필 사진
    - 사용자가 프로필 사진을 설정하고 수정할 수 있도록 바뀜에 따라서 채팅방에서 사용자의 프로필 사진이 보이도록 설정
    - 채팅방의 메세지 데이터를 불러올 때 사용자의 프로필 사진도 함께 불러와야 해서 그 부분도 수정
- 로그인 페이지
    - 로그인 페이지에서 보이는 화면을 살짝 수정
    - 회원가입 시, 이메일 인증을 할 때 5분 타이머가 돌아가도록 설정
- 프로젝트(보드) 페이지
    - 1) 프로젝트 상세 페이지: 오프캔버스(사이드메뉴바)에 보드 마감일과 설명 추가, 보드 수정 버튼 추가
    - 2) 달력 페이지: 카드 색상 변경
- 마이페이지
    - 마이페이지를 들어가면 프로필이 바로 보이도록 수정

## 전달 사항
- 프론트를 수정하면서 서버쪽 코드도 일부 수정되어서 같이 확인해주시면 감사하겠습니다
- 한 가지 여쭤보고 싶은건, 제가 이메일 인증 부분 프론트를 수정하면서 서버쪽 코드를 수정했습니다
    - 예외를 throw 해주면 프론트에서는 어떤 이유로 오류가 발생했는지 알 수 없어서 return badRequest를 추가했습니다
    - 우선 테스트 삼아, 이메일이 보내지지 않은 경우에만 return ResponseEntity.badRequest를 추가했는데,
    - 중복된 이메일일 경우에도 return ResponseEntity.badRequest나 다른 상태코드로 return할 지 고민입니다.
    - 프론트에서는 우선 중복 이메일과 이메일이 보내지지 않는 경우를 나눠서 alert 창을 띄우도록 했습니다.