### PR TITLE
게시글 검색 페이지 페이징 오류 해결

### DIFF
--- a/src/main/java/com/sangbu3jo/elephant/posts/controller/PostViewController.java
+++ b/src/main/java/com/sangbu3jo/elephant/posts/controller/PostViewController.java
@@ -58,6 +58,7 @@ public class PostViewController {
       Model model) {
 
     checkAdmin(model,userDetails);
+    pageNo = (pageNo == 0) ? 0 : (pageNo - 1);
     Page<PostResponseDto> postResponseDtoList = postService.getSearchTitle(category, pageable,
         pageNo, title);
     model.addAttribute("categoryName", Category.getCategory(category));
@@ -104,7 +105,7 @@ public class PostViewController {
   //게시글 생성 페이지로 이동
   @GetMapping("/post-page")
   public String createPost(@RequestParam("category") int category,
-                           Model model) {
+      Model model) {
     model.addAttribute("choice", category);
     return "createPost";
   }
@@ -131,6 +132,6 @@ public class PostViewController {
       model.addAttribute("admin", admin);
     }
   }
-   
+
 }
   

--- a/src/main/resources/templates/searchedPage.html
+++ b/src/main/resources/templates/searchedPage.html
@@ -188,7 +188,7 @@
       <ul class="pagination justify-content-center custom-pagination">
         <li class="page-item" th:classappend="${!posts.hasPrevious()} ? 'disabled'">
           <a class="page-link"
-             th:href="@{|?page=${posts.getPageable().getPageNumber() - 1}|}">
+             th:href="@{|?title=${searchedTitle}&page=${posts.getPageable().getPageNumber() - 1}|}">
             <span>이전</span>
           </a>
         </li>
@@ -196,13 +196,13 @@
             th:if="${page >= page - 5 and page <= page + 5}"
             class="page-item">
           <a th:text="${page + 1}" class="page-link"
-             th:href="@{|?page=${page + 1}|}"
+             th:href="@{|?title=${searchedTitle}&page=${page + 1}|}"
              th:style="${page == posts.getPageable().getPageNumber()} ? 'background-color: #f5f5fa;' : ''">1</a>
         </li>
 
 
         <li class="page-item" th:classappend="${!posts.hasNext()} ? 'disabled'">
-          <a class="page-link" th:href="@{|/page=${posts.getPageable().getPageNumber() + 2}|}">
+          <a class="page-link" th:href="@{|/api/posts/categories/${category}/titles?title=${searchedTitle}&page=${posts.getPageable().getPageNumber() + 2}|}">
             <span>다음</span>
           </a>
         </li>


### PR DESCRIPTION
## 바꾼 이유
- 게시글을 검색하는 페이지에서 페이지 이동 미작동

## 주요 변화
- 게시글 검색 페이지의 이전, 페이징 번호, 다음 기능 작동되도록 반영

## 전달 사항
- 게시글 검색 페이지의 페이징 완료되어서 테스트까지 완료하였습니다.
