### PR TITLE
Chj img edit

### DIFF
--- a/src/main/java/com/sangbu3jo/elephant/users/controller/UserController.java
+++ b/src/main/java/com/sangbu3jo/elephant/users/controller/UserController.java
@@ -59,11 +59,11 @@ public class UserController {
      */
     @PostMapping("/users/profile/image")
     public ResponseEntity<String> updateImg(@AuthenticationPrincipal UserDetailsImpl userDetails,
-                                            @RequestParam MultipartFile image,
-                                            @RequestParam(name = "profileUrl") String profileUrl
+                                            @RequestParam MultipartFile image
+
                                            ) throws IOException {
 
-        String result = userService.updateImg(userDetails.getUser(), image,profileUrl);
+        String result = userService.updateImg(userDetails.getUser(), image);
 
         return ResponseEntity.ok(result);
     }

--- a/src/main/java/com/sangbu3jo/elephant/users/service/UserService.java
+++ b/src/main/java/com/sangbu3jo/elephant/users/service/UserService.java
@@ -22,8 +22,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
+import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -84,7 +83,7 @@ public class UserService {
      */
 
 
-    public String updateImg(User requestuser, MultipartFile image, String profileUrl) throws IOException {
+    public String updateImg(User requestuser, MultipartFile image) throws IOException {
 
         // 유저 조회
         User user = userRepository.findById(requestuser.getId()).orElse(null);
@@ -103,12 +102,17 @@ public class UserService {
             String storedFileName = s3UploaderService.upload(image, "image");
 
             if (user.getOldProfile() != null && !user.getOldProfile().isEmpty()) {
-                String oldUrl = user.getOldProfile();
-                deleteImage(oldUrl);
+                try {
+                    String oldUrl = URLDecoder.decode(user.getOldProfile(), "UTF-8");
+
+                    deleteImage(oldUrl);
+                }catch (UnsupportedEncodingException e) {
+                    e.printStackTrace();
+                }
             }
 
             // 값을 받아오면 같은 값 넣어주기
-            user.setOldProfile(profileUrl);
+            user.setOldProfile(storedFileName);
             user.setProfileUrl(storedFileName);
 
         }

--- a/src/main/resources/templates/backUsers.html
+++ b/src/main/resources/templates/backUsers.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
 
     <title>코끼리</title>
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
@@ -29,7 +30,7 @@
     <style>
 
     </style>
-    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
+
 </head>
 <body>
 
@@ -1273,9 +1274,7 @@
         // 프로필 이미지 업로드 버튼에 클릭 이벤트를 추가하고 이미지를 선택하면 AJAX를 통해 서버로 업로드
         uploadImageButton.addEventListener('click', () => {
             const file = imageInput.files[0];
-            var profileUrl = `${profileUrl}`;
 
-            console.log(profileUrl);
 
 
             if (file) {
@@ -1286,7 +1285,7 @@
 
                 // AJAX 요청을 보내고 이미지 URL을 서버로 업로드
                 $.ajax({
-                    url: `/api/users/profile/image?profileUrl=${profileUrl}`, // 서버 업로드 URL로 변경
+                    url: `/api/users/profile/image`, // 서버 업로드 URL로 변경
                     type: 'POST',
                     data: formData,
                     contentType: false,

--- a/src/main/resources/templates/createPost.html
+++ b/src/main/resources/templates/createPost.html
@@ -5,6 +5,7 @@
     <meta name="viewport"
           content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
     <title>코끼리</title>
 
     <script src="https://code.jquery.com/jquery-latest.min.js"></script>
@@ -30,7 +31,7 @@
 
     </style>
 
-    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
+
 </head>
 <body>
 <div class="top">

--- a/src/main/resources/templates/login-page.html
+++ b/src/main/resources/templates/login-page.html
@@ -6,6 +6,7 @@
     <meta name="viewport"
           content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
     <script src="https://code.jquery.com/jquery-3.7.0.min.js"
             integrity="sha256-2Pmvv0kuTBOenSvLm6bvfBSSHrUJ+3A7x6P5Ebd07/g="
             crossorigin="anonymous"></script>

--- a/src/main/resources/templates/updatePost.html
+++ b/src/main/resources/templates/updatePost.html
@@ -5,6 +5,7 @@
     <meta name="viewport"
           content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
     <title>코끼리</title>
 
     <script src="https://code.jquery.com/jquery-latest.min.js"></script>
@@ -31,7 +32,7 @@
 
     </style>
 
-    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
+
 
 
 </head>


### PR DESCRIPTION
## 바꾼 이유

- http-> https mixed content 해결 하기 위함 
- 프로필 이미지를 변경을 하면 이전에 프로필 이미지가 s3 객체에 지속적으로 쌓이기 때문에 방지하기 위함  

## 주요 변화

- createPost backUser updatePost  html 파일에 메타 태그를 상단으로 이동 시켰습니다 
- userService에 인코딩화 되어 저장되는 url 주소를 다시 decode해서 객체의 키값과 비교를 통해 이전 프로필 이미지가 삭제가 되게 되었습니다. 

## 전달 사항

-아직 mixed content 에러는 해결을 하지 못했습니다 우선 많은 블로그에서 사용하는 메타 태그를 상단으로 올려서 다시 pr하겠습니다 그리고 해결 방법을 더 찾아보겠습니다. 
