### PR TITLE
FEAT : 1:1 채팅시 알림이 전달되도록 코드 추가

### DIFF
--- a/src/main/java/com/sangbu3jo/elephant/chat/repository/GroupChatRoomRepository.java
+++ b/src/main/java/com/sangbu3jo/elephant/chat/repository/GroupChatRoomRepository.java
@@ -1,8 +1,12 @@
 package com.sangbu3jo.elephant.chat.repository;
 
 import com.sangbu3jo.elephant.chat.entity.GroupChatRoom;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface GroupChatRoomRepository extends JpaRepository<GroupChatRoom, Long> {
     GroupChatRoom findByTitle(String chatRoomId);
+    @Query("SELECT p.id FROM GroupChatRoom p WHERE p.title = :title")
+    Long findIdByTitle(@Param("title") String title);
 }

--- a/src/main/java/com/sangbu3jo/elephant/chat/repository/PrivateChatRoomRepository.java
+++ b/src/main/java/com/sangbu3jo/elephant/chat/repository/PrivateChatRoomRepository.java
@@ -17,4 +17,10 @@ public interface PrivateChatRoomRepository extends JpaRepository<PrivateChatRoom
     List<PrivateChatRoom> findByUser(String username);
 
     Optional<PrivateChatRoom> findByTitle(String chatRoomId);
+
+    @Query("SELECT p.user1 FROM PrivateChatRoom p WHERE p.title = :title")
+    Optional<String> findUser1ByTitle(@Param("title") String title);
+
+    @Query("SELECT p.user2 FROM PrivateChatRoom p WHERE p.title = :title")
+    Optional<String> findUser2ByTitle(@Param("title") String title);
 }

--- a/src/main/java/com/sangbu3jo/elephant/notification/service/NotificationService.java
+++ b/src/main/java/com/sangbu3jo/elephant/notification/service/NotificationService.java
@@ -10,7 +10,6 @@ import com.sangbu3jo.elephant.users.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.MediaType;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -61,7 +60,7 @@ public class NotificationService {
 
             for (SseEmitter emitter : emitters) {
                 try {
-                    emitter.send(SseEmitter.event().data(notificationJson), MediaType.TEXT_EVENT_STREAM);
+                    emitter.send(SseEmitter.event().data(notificationJson));
                 } catch (IOException e) {
                     // 연결이 끊긴 경우, 여기서 처리 가능
                     emittersToRemove.add(emitter); // 연결이 끊긴 emitter를 제거할 리스트에 추가
@@ -138,7 +137,7 @@ public class NotificationService {
         sendNotificationToUser(userId, notification);
     }
 
-    // 초대시 알림 생성 및 전송
+    // 프로젝트 마감 임박시 알림 생성 및 전송
     public void inviteAndSendNotification(Long userId, String inviteAuthor){
         Notification notification = new Notification();
         LocalDateTime currentTime = LocalDateTime.now(); // 현재 시간 가져오기
@@ -148,6 +147,21 @@ public class NotificationService {
         notification.setUrl("/api/boards");
         notification.setRead(false);
         notification.setType("Invited");
+
+        notificationRepository.save(notification);
+        sendNotificationToUser(userId, notification);
+    }
+
+    // 개인 메시지 알림 생성 및 전송
+    public void oneMessgeNotification(Long userId, String inviteAuthor, String url){
+        Notification notification = new Notification();
+        LocalDateTime currentTime = LocalDateTime.now(); // 현재 시간 가져오기
+        notification.setCreatedAt(currentTime); // 생성 시간 설정
+        notification.setUserId(userId);
+        notification.setContent("\uD83D\uDCE71:1 메시지 알림\uD83D\uDCE7<br>" + inviteAuthor);
+        notification.setUrl(url);
+        notification.setRead(false);
+        notification.setType("1:1 messge");
 
         notificationRepository.save(notification);
         sendNotificationToUser(userId, notification);

--- a/src/main/java/com/sangbu3jo/elephant/users/repository/UserRepository.java
+++ b/src/main/java/com/sangbu3jo/elephant/users/repository/UserRepository.java
@@ -2,9 +2,9 @@ package com.sangbu3jo.elephant.users.repository;
 
 import com.sangbu3jo.elephant.users.custom.UserRepositorySupport;
 import com.sangbu3jo.elephant.users.entity.User;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.querydsl.QuerydslPredicateExecutor;
+
+import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User,Long>, UserRepositorySupport /*QuerydslPredicateExecutor<User>*/ {
   Optional<User> findByUsername(String username);
@@ -14,4 +14,6 @@ public interface UserRepository extends JpaRepository<User,Long>, UserRepository
   Optional<User> findByNaverId(String naverId);
 
   boolean existsByUsername(String username);
+
+  Optional<User> findUserIdByUsername(String username);
 }


### PR DESCRIPTION
## 바꾼 이유

- 1:1 채팅 메시지 전송시 수신자에게 알림이 전송되도록 기존 ChatRoomService, Notification안에 코드를 추가 작성 하였습니다.
- 1:1 채팅방에서 채팅작성시 메시지를 전달받은 유저에게 SSE알림이 전송됩니다. 전달받을 유저가 로그오프 상태일시 로그인 하게 되면 기존에 저장된 DB에서 알림을 조회하여 받을 수 있도록 구현하였습니다.

## 주요 변화

- 1:1 채팅 메시지 전송시 상대방에게 알림 기능 추가

## 전달 사항

- 로컬에서 테스트 결과 DB상으로는 문제없는 것 확인했습니다. 오늘 오전에 직접 메시지 주고받으며 테스트가 필요할 것 같습니다.
