### PR TITLE
REFACTOR : 게시글 숨김처리시 사진도 지워지도록 코드 수정

### DIFF
--- a/src/main/java/com/sangbu3jo/elephant/admin/service/AdminService.java
+++ b/src/main/java/com/sangbu3jo/elephant/admin/service/AdminService.java
@@ -137,6 +137,8 @@ public class AdminService {
 
         post.setTitle("숨김 처리된 게시글입니다.");
         post.setContent("숨김 처리된 게시글입니다.");
+        post.setFiles(null);
+
         return "게시글 숨김처리가 완료되었습니다";
     }
 


### PR DESCRIPTION
## 바꾼 이유

- 게시글 숨김처리시 사진이 남아있는 부분을 수정했습니다

## 주요 변화

- 관리자가 게시글 숨김처리시 사진의 String값 null처리

## 전달 사항

- 딱 한줄만 추가됐습니다!
