### PR TITLE
[FIX] 게시판 문제은행 이미지 없이 completed null 값 해결

### DIFF
--- a/src/main/resources/templates/updatePost.html
+++ b/src/main/resources/templates/updatePost.html
@@ -330,6 +330,10 @@
                     completed: completed
                 };
 
+                if(postData.completed == null){
+                    postData.completed = false;
+                }
+
                 Swal.fire({
                     title: "게시글을 수정 하시겠습니까?",
                     text: '게시글을 수정합니다.',


### PR DESCRIPTION
## 바꾼 이유

-게시판 이미지 없이 변경을 하니깐 completed 값에 null이 들어가서 오류 

## 주요 변화

-조건문을 추가해 null 이 들어오면 false값을 갖게 설정했습니다 

## 전달 사항

-
