### PR TITLE
REFACTOR : 게시글 제목에 댓글수 + 사진있을시 아이콘 추가 표시하도록 코드 수정

### DIFF
--- a/src/main/resources/templates/category.html
+++ b/src/main/resources/templates/category.html
@@ -178,8 +178,13 @@
 
       <a th:onclick="'gotoPost(\'' + ${post.id} + '\')'" class="list-group-item list-group-item-action" aria-current="true" th:each="post, postIndex : ${posts}">
         <div class="d-flex w-75 justify-content-between">
-          <h5 class="card-title mb-0" th:text="|${post.title.length() > 15 ? #strings.substring(post.title, 0, 15) + '...' : post.title}|">스터디원 구함 </h5>
+          <h5 class="card-title mb-0">
+            <span th:text="|${(post.title.length() > 15 ? #strings.substring(post.title, 0, 15) + '...' : post.title)}|"></span>
+            <span th:if="${post.getPostCommentList().size() > 0}" th:text="${' (' + post.getPostCommentList().size() + ')'}"> (댓글갯수)</span>
+            <span th:if="${post.files != null}" style="font-size: smaller;">🖼️</span>
+          </h5>
           <p class="card-text mb-0" th:text="|${post.content.length() > 50 ? #strings.substring(post.content, 0, 50) + '...' : post.content}|">Some quick example text to build on the card title ...</p>
+
         </div>
         <div class="d-flex w-25 justify-content-between">
           <div style="width: 40%; display: flex; justify-content: center; align-items: center;">

--- a/src/main/resources/templates/mainPage.html
+++ b/src/main/resources/templates/mainPage.html
@@ -134,7 +134,11 @@
                     <ul class="list-group list-group-flush">
                         <li class="list-group-item d-flex justify-content-between align-items-center"
                             th:each="project : ${projects}" th:onclick="'gotoPost(\'' + ${project.id} + '\')'">
-                            <span th:text="|${project.title.length() > 30 ? #strings.substring(project.title, 0, 30) + '...' : project.title}|">제목</span>
+                            <span>
+                                <span th:text="|${(project.title.length() > 20 ? #strings.substring(project.title, 0, 20) + '...' : project.title)}|">제목</span>
+                                <span th:if="${project.getPostCommentList.size() > 0}" th:text="${' (' + project.getPostCommentList.size() + ')'}"> (댓글갯수)</span>
+                                <span th:if="${project.files != null}" style="font-size: smaller;">🖼️</span>
+                            </span>
                             <span th:text="${project.nickname}">작성자</span>
                             <span class="badge bg-primary rounded-pill"
                                   th:text="|조회수: ${project.view_cnt}|">조회수: 1</span>
@@ -150,7 +154,11 @@
                     <ul class="list-group list-group-flush">
                         <li class="list-group-item d-flex justify-content-between align-items-center"
                             th:each="study : ${studies}" th:onclick="'gotoPost(\'' + ${study.id} + '\')'">
-                            <span th:text="|${study.title.length() > 20 ? #strings.substring(study.title, 0, 20) + '...' : study.title}|">제목</span>
+                            <span>
+                                <span th:text="|${(study.title.length() > 20 ? #strings.substring(study.title, 0, 20) + '...' : study.title)}|">제목</span>
+                                <span th:if="${study.getPostCommentList.size() > 0}" th:text="${' (' + study.getPostCommentList.size() + ')'}"> (댓글갯수)</span>
+                                <span th:if="${study.files != null}" style="font-size: smaller;">🖼️</span>
+                            </span>
                             <span th:text="${study.nickname}">작성자</span>
                             <span class="badge bg-primary rounded-pill" th:text="|조회수: ${study.view_cnt}|">조회수: 1</span>
                         </li>
@@ -169,7 +177,11 @@
                 <ul class="list-group list-group-flush">
                     <li class="list-group-item d-flex justify-content-between align-items-center"
                         th:each="exam : ${exams}"  th:onclick="'gotoPost(\'' + ${exam.id} + '\')'">
-                        <span th:text="|${exam.title.length() > 20 ? #strings.substring(exam.title, 0, 20) + '...' : exam.title}|">제목</span>
+                        <span>
+                            <span th:text="|${(exam.title.length() > 20 ? #strings.substring(exam.title, 0, 20) + '...' : exam.title)}|">제목</span>
+                            <span th:if="${exam.getPostCommentList.size() > 0}" th:text="${' (' + exam.getPostCommentList.size() + ')'}"> (댓글갯수)</span>
+                            <span th:if="${exam.files != null}" style="font-size: smaller;">🖼️</span>
+                        </span>
                         <span th:text="${exam.nickname}">작성자</span>
                         <span class="badge bg-primary rounded-pill" th:text="|조회수: ${exam.view_cnt}|">조회수: 1</span>
                     </li>
@@ -184,7 +196,11 @@
                 <ul class="list-group list-group-flush">
                     <li class="list-group-item d-flex justify-content-between align-items-center"
                         th:each="forum : ${forums}"  th:onclick="'gotoPost(\'' + ${forum.id} + '\')'">
-                        <span th:text="|${forum.title.length() > 20 ? #strings.substring(forum.title, 0, 20) + '...' : forum.title}|">제목</span>
+                        <span>
+                            <span th:text="|${(forum.title.length() > 20 ? #strings.substring(forum.title, 0, 20) + '...' : forum.title)}|">제목</span>
+                            <span th:if="${forum.getPostCommentList.size() > 0}" th:text="${' (' + forum.getPostCommentList.size() + ')'}"> (댓글갯수)</span>
+                            <span th:if="${forum.files != null}" style="font-size: smaller;">🖼️</span>
+                        </span>
                         <span th:text="${forum.nickname}">작성자</span>
                         <span class="badge bg-primary rounded-pill"  th:text="|조회수: ${forum.view_cnt}|">조회수: 1</span>
                     </li>

--- a/src/main/resources/templates/searchedPage.html
+++ b/src/main/resources/templates/searchedPage.html
@@ -175,7 +175,11 @@
 
       <a th:onclick="'gotoPost(\'' + ${post.id} + '\')'" class="list-group-item list-group-item-action" aria-current="true" th:each="post, postIndex : ${posts}">
         <div class="d-flex w-75 justify-content-between">
-          <h5 class="card-title mb-0" th:text="|${post.title.length() > 15 ? #strings.substring(post.title, 0, 15) + '...' : post.title}|">스터디원 구함 </h5>
+          <h5 class="card-title mb-0">
+            <span th:text="|${(post.title.length() > 15 ? #strings.substring(post.title, 0, 15) + '...' : post.title)}|"></span>
+            <span th:if="${post.getPostCommentList().size() > 0}" th:text="${' (' + post.getPostCommentList().size() + ')'}"> (댓글갯수)</span>
+            <span th:if="${post.files != null}" style="font-size: smaller;">🖼️</span>
+          </h5>
           <p class="card-text mb-0" th:text="|${post.content.length() > 50 ? #strings.substring(post.content, 0, 50) + '...' : post.content}|">Some quick example text to build on the card title ...</p>
         </div>
         <div class="d-flex w-25 justify-content-between">


### PR DESCRIPTION
## 바꾼 이유

- 게시글만 있으니 뭔가 허전해서 추가했습니다

## 주요 변화

- 메인 페이지 적용
- 카테고리 페이지 적용
- 검색 페이지 적용
- 게시글 상세 페이지 (미적용) 상세페이지는 기존 그대로 유지 했습니다.

## 전달 사항

- 고생하셨습니다
